### PR TITLE
refactor: Introduce SpotifyUri struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,11 +37,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [connect] Replaced `SpircLoadCommand` with `LoadRequest`, `LoadRequestOptions` and `LoadContextOptions` (breaking)
 - [connect] Moved all public items to the highest level (breaking)
 - [connect] Replaced Mercury usage in `Spirc` with Dealer
+- [connect] Changed `track_id` parameter in `SpircTask::handle_unavailable` from `SpotifyId` to `&SpotifyUri` (breaking)
+- [connect] Changed return type of `ConnectState::preview_next_track` from `Option<SpotifyId>` to
+  `Option<SpotifyUri>` (breaking)
+- [connect] Changed type of `id` parameter `ConnectState::mark_unavailable` from `SpotifyId` to `&SpotifyUri` (breaking)
 - [metadata] Replaced `AudioFileFormat` with own enum. (breaking)
 - [playback] Changed trait `Mixer::open` to return `Result<Self, Error>` instead of `Self` (breaking)
 - [playback] Changed type alias `MixerFn` to return `Result<Arc<dyn Mixer>, Error>` instead of `Arc<dyn Mixer>` (breaking)
 - [playback] Optimize audio conversion to always dither at 16-bit level, and improve performance
 - [playback] Normalizer maintains better stereo imaging, while also being faster
+- [playback] Changed type of `SpotifyId` fields in `PlayerEvent` members to `SpotifyUri` (breaking)
 - [oauth] Remove loopback address requirement from `redirect_uri` when spawning callback handling server versus using stdin.
 
 ### Added
@@ -53,8 +58,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [connect] Add and enforce rustdoc
 - [playback] Add `track` field to `PlayerEvent::RepeatChanged` (breaking)
 - [playback] Add `PlayerEvent::PositionChanged` event to notify about the current playback position
+- [playback] Add `load_uri()` function to load a `SpotifyUri`
+- [playback] Add `preload_uri()` function to load a `SpotifyUr
 - [core] Add `request_with_options` and `request_with_protobuf_and_options` to `SpClient`
 - [core] Add `try_get_urls` to `CdnUrl`
+- [core] Add `SpotifyUri` type to represent more types of URI than `SpotifyId` can
 - [oauth] Add `OAuthClient` and `OAuthClientBuilder` structs to achieve a more customizable login process
 
 ### Fixed
@@ -81,6 +89,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [oauth] `get_access_token()` function marked for deprecation
 - [core] `try_get_url()` function marked for deprecation
+- [player] `load()` function marked for deprecation
+- [player] `preload()` function marked for deprecation
 
 ### Removed
 

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -2,7 +2,7 @@ use crate::{
     LoadContextOptions, LoadRequestOptions, PlayContext,
     context_resolver::{ContextAction, ContextResolver, ResolveContext},
     core::{
-        Error, Session, SpotifyId,
+        Error, Session, SpotifyUri,
         authentication::Credentials,
         dealer::{
             manager::{BoxedStream, BoxedStreamResult, Reply, RequestReply},
@@ -778,7 +778,7 @@ impl SpircTask {
                 return Ok(());
             }
             PlayerEvent::Unavailable { track_id, .. } => {
-                self.handle_unavailable(track_id)?;
+                self.handle_unavailable(&track_id)?;
                 if self.connect_state.current_track(|t| &t.uri) == &track_id.to_uri()? {
                     self.handle_next(None)?
                 }
@@ -1494,12 +1494,12 @@ impl SpircTask {
         }
 
         if let Some(track_id) = self.connect_state.preview_next_track() {
-            self.player.preload(track_id);
+            self.player.preload_uri(track_id);
         }
     }
 
     // Mark unavailable tracks so we can skip them later
-    fn handle_unavailable(&mut self, track_id: SpotifyId) -> Result<(), Error> {
+    fn handle_unavailable(&mut self, track_id: &SpotifyUri) -> Result<(), Error> {
         self.connect_state.mark_unavailable(track_id)?;
         self.handle_preload_next_track();
 
@@ -1704,8 +1704,8 @@ impl SpircTask {
         }
 
         let current_uri = self.connect_state.current_track(|t| &t.uri);
-        let id = SpotifyId::from_uri(current_uri)?;
-        self.player.load(id, start_playing, position_ms);
+        let id = SpotifyUri::from_uri(current_uri)?;
+        self.player.load_uri(id, start_playing, position_ms);
 
         self.connect_state
             .update_position(position_ms, self.now_ms());

--- a/connect/src/state/context.rs
+++ b/connect/src/state/context.rs
@@ -1,5 +1,5 @@
 use crate::{
-    core::{Error, SpotifyId},
+    core::{Error, SpotifyUri},
     protocol::{
         context::Context,
         context_page::ContextPage,
@@ -14,6 +14,7 @@ use crate::{
         provider::{IsProvider, Provider},
     },
 };
+use librespot_core::spotify_id::SpotifyItemType;
 use protobuf::MessageField;
 use std::collections::HashMap;
 use uuid::Uuid;
@@ -444,8 +445,8 @@ impl ConnectState {
             (Some(uri), _) if uri.contains(['?', '%']) => {
                 Err(StateError::InvalidTrackUri(Some(uri.clone())))?
             }
-            (Some(uri), _) if !uri.is_empty() => SpotifyId::from_uri(uri)?,
-            (_, Some(gid)) if !gid.is_empty() => SpotifyId::from_raw(gid)?,
+            (Some(uri), _) if !uri.is_empty() => SpotifyUri::from_uri(uri)?,
+            (_, Some(gid)) if !gid.is_empty() => SpotifyUri::from_raw(gid, SpotifyItemType::Track)?,
             _ => Err(StateError::InvalidTrackUri(None))?,
         };
 

--- a/connect/src/state/tracks.rs
+++ b/connect/src/state/tracks.rs
@@ -1,5 +1,5 @@
 use crate::{
-    core::{Error, SpotifyId},
+    core::{Error, SpotifyUri},
     protocol::player::ProvidedTrack,
     state::{
         ConnectState, SPOTIFY_MAX_NEXT_TRACKS_SIZE, SPOTIFY_MAX_PREV_TRACKS_SIZE, StateError,
@@ -348,14 +348,14 @@ impl<'ct> ConnectState {
         Ok(())
     }
 
-    pub fn preview_next_track(&mut self) -> Option<SpotifyId> {
+    pub fn preview_next_track(&mut self) -> Option<SpotifyUri> {
         let next = if self.repeat_track() {
             self.current_track(|t| &t.uri)
         } else {
             &self.next_tracks().first()?.uri
         };
 
-        SpotifyId::from_uri(next).ok()
+        SpotifyUri::from_uri(next).ok()
     }
 
     pub fn has_next_tracks(&self, min: Option<usize>) -> bool {
@@ -377,7 +377,7 @@ impl<'ct> ConnectState {
         prev
     }
 
-    pub fn mark_unavailable(&mut self, id: SpotifyId) -> Result<(), Error> {
+    pub fn mark_unavailable(&mut self, id: &SpotifyUri) -> Result<(), Error> {
         let uri = id.to_uri()?;
 
         debug!("marking {uri} as unavailable");

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -32,6 +32,7 @@ mod socket;
 #[allow(dead_code)]
 pub mod spclient;
 pub mod spotify_id;
+pub mod spotify_uri;
 pub mod token;
 #[doc(hidden)]
 pub mod util;
@@ -42,3 +43,4 @@ pub use error::Error;
 pub use file_id::FileId;
 pub use session::Session;
 pub use spotify_id::SpotifyId;
+pub use spotify_uri::SpotifyUri;

--- a/core/src/spclient.rs
+++ b/core/src/spclient.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::config::{OS, os_version};
 use crate::{
-    Error, FileId, SpotifyId,
+    Error, FileId, SpotifyId, SpotifyUri,
     apresolve::SocketAddress,
     config::SessionConfig,
     error::ErrorKind,
@@ -676,10 +676,10 @@ impl SpClient {
             .await
     }
 
-    pub async fn get_radio_for_track(&self, track_id: &SpotifyId) -> SpClientResult {
+    pub async fn get_radio_for_track(&self, track_uri: &SpotifyUri) -> SpClientResult {
         let endpoint = format!(
             "/inspiredby-mix/v2/seed_to_playlist/{}?response-format=json",
-            track_id.to_uri()?
+            track_uri.to_uri()?
         );
 
         self.request_as_json(&Method::GET, &endpoint, None, None)

--- a/core/src/spotify_id.rs
+++ b/core/src/spotify_id.rs
@@ -1,10 +1,8 @@
-use std::{fmt, ops::Deref};
+use std::fmt;
 
 use thiserror::Error;
 
 use crate::Error;
-
-use librespot_protocol as protocol;
 
 // re-export FileId for historic reasons, when it was part of this mod
 pub use crate::FileId;
@@ -25,6 +23,7 @@ impl From<&str> for SpotifyItemType {
     fn from(v: &str) -> Self {
         match v {
             "album" => Self::Album,
+
             "artist" => Self::Artist,
             "episode" => Self::Episode,
             "playlist" => Self::Playlist,
@@ -54,14 +53,13 @@ impl From<SpotifyItemType> for &str {
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct SpotifyId {
     pub id: u128,
-    pub item_type: SpotifyItemType,
 }
 
 #[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
 pub enum SpotifyIdError {
     #[error("ID cannot be parsed")]
     InvalidId,
-    #[error("not a valid Spotify URI")]
+    #[error("not a valid Spotify ID")]
     InvalidFormat,
     #[error("URI does not belong to Spotify")]
     InvalidRoot,
@@ -74,7 +72,6 @@ impl From<SpotifyIdError> for Error {
 }
 
 pub type SpotifyIdResult = Result<SpotifyId, Error>;
-pub type NamedSpotifyIdResult = Result<NamedSpotifyId, Error>;
 
 const BASE62_DIGITS: &[u8; 62] = b"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 const BASE16_DIGITS: &[u8; 16] = b"0123456789abcdef";
@@ -82,15 +79,6 @@ const BASE16_DIGITS: &[u8; 16] = b"0123456789abcdef";
 impl SpotifyId {
     const SIZE: usize = 16;
     const SIZE_BASE16: usize = 32;
-    const SIZE_BASE62: usize = 22;
-
-    /// Returns whether this `SpotifyId` is for a playable audio item, if known.
-    pub fn is_playable(&self) -> bool {
-        matches!(
-            self.item_type,
-            SpotifyItemType::Episode | SpotifyItemType::Track
-        )
-    }
 
     /// Parses a base16 (hex) encoded [Spotify ID] into a `SpotifyId`.
     ///
@@ -114,10 +102,7 @@ impl SpotifyId {
             dst += p;
         }
 
-        Ok(Self {
-            id: dst,
-            item_type: SpotifyItemType::Unknown,
-        })
+        Ok(Self { id: dst })
     }
 
     /// Parses a base62 encoded [Spotify ID] into a `u128`.
@@ -143,10 +128,7 @@ impl SpotifyId {
             dst = dst.checked_add(p).ok_or(SpotifyIdError::InvalidId)?;
         }
 
-        Ok(Self {
-            id: dst,
-            item_type: SpotifyItemType::Unknown,
-        })
+        Ok(Self { id: dst })
     }
 
     /// Creates a `u128` from a copy of `SpotifyId::SIZE` (16) bytes in big-endian order.
@@ -156,63 +138,9 @@ impl SpotifyId {
         match src.try_into() {
             Ok(dst) => Ok(Self {
                 id: u128::from_be_bytes(dst),
-                item_type: SpotifyItemType::Unknown,
             }),
             Err(_) => Err(SpotifyIdError::InvalidId.into()),
         }
-    }
-
-    /// Parses a [Spotify URI] into a `SpotifyId`.
-    ///
-    /// `uri` is expected to be in the canonical form `spotify:{type}:{id}`, where `{type}`
-    /// can be arbitrary while `{id}` is a 22-character long, base62 encoded Spotify ID.
-    ///
-    /// Note that this should not be used for playlists, which have the form of
-    /// `spotify:playlist:{id}`.
-    ///
-    /// [Spotify URI]: https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids
-    pub fn from_uri(src: &str) -> SpotifyIdResult {
-        // Basic: `spotify:{type}:{id}`
-        // Named: `spotify:user:{user}:{type}:{id}`
-        // Local: `spotify:local:{artist}:{album_title}:{track_title}:{duration_in_seconds}`
-        let mut parts = src.split(':');
-
-        let scheme = parts.next().ok_or(SpotifyIdError::InvalidFormat)?;
-
-        let item_type = {
-            let next = parts.next().ok_or(SpotifyIdError::InvalidFormat)?;
-            if next == "user" {
-                let _username = parts.next().ok_or(SpotifyIdError::InvalidFormat)?;
-                parts.next().ok_or(SpotifyIdError::InvalidFormat)?
-            } else {
-                next
-            }
-        };
-
-        let id = parts.next().ok_or(SpotifyIdError::InvalidFormat)?;
-
-        if scheme != "spotify" {
-            return Err(SpotifyIdError::InvalidRoot.into());
-        }
-
-        let item_type = item_type.into();
-
-        // Local files have a variable-length ID: https://developer.spotify.com/documentation/general/guides/local-files-spotify-playlists/
-        // TODO: find a way to add this local file ID to SpotifyId.
-        // One possible solution would be to copy the contents of `id` to a new String field in SpotifyId,
-        // but then we would need to remove the derived Copy trait, which would be a breaking change.
-        if item_type == SpotifyItemType::Local {
-            return Ok(Self { item_type, id: 0 });
-        }
-
-        if id.len() != Self::SIZE_BASE62 {
-            return Err(SpotifyIdError::InvalidId.into());
-        }
-
-        Ok(Self {
-            item_type,
-            ..Self::from_base62(id)?
-        })
     }
 
     /// Returns the `SpotifyId` as a base16 (hex) encoded, `SpotifyId::SIZE_BASE16` (32)
@@ -274,124 +202,19 @@ impl SpotifyId {
     pub fn to_raw(&self) -> [u8; Self::SIZE] {
         self.id.to_be_bytes()
     }
-
-    /// Returns the `SpotifyId` as a [Spotify URI] in the canonical form `spotify:{type}:{id}`,
-    /// where `{type}` is an arbitrary string and `{id}` is a 22-character long, base62 encoded
-    /// Spotify ID.
-    ///
-    /// If the `SpotifyId` has an associated type unrecognized by the library, `{type}` will
-    /// be encoded as `unknown`.
-    ///
-    /// [Spotify URI]: https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids
-    #[allow(clippy::wrong_self_convention)]
-    pub fn to_uri(&self) -> Result<String, Error> {
-        // 8 chars for the "spotify:" prefix + 1 colon + 22 chars base62 encoded ID  = 31
-        // + unknown size item_type.
-        let item_type: &str = self.item_type.into();
-        let mut dst = String::with_capacity(31 + item_type.len());
-        dst.push_str("spotify:");
-        dst.push_str(item_type);
-        dst.push(':');
-        let base_62 = self.to_base62()?;
-        dst.push_str(&base_62);
-
-        Ok(dst)
-    }
 }
 
 impl fmt::Debug for SpotifyId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("SpotifyId")
-            .field(&self.to_uri().unwrap_or_else(|_| "invalid uri".into()))
+            .field(&self.to_base62().unwrap_or_else(|_| "invalid uri".into()))
             .finish()
     }
 }
 
 impl fmt::Display for SpotifyId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.to_uri().unwrap_or_else(|_| "invalid uri".into()))
-    }
-}
-
-#[derive(Clone, PartialEq, Eq, Hash)]
-pub struct NamedSpotifyId {
-    pub inner_id: SpotifyId,
-    pub username: String,
-}
-
-impl NamedSpotifyId {
-    pub fn from_uri(src: &str) -> NamedSpotifyIdResult {
-        let uri_parts: Vec<&str> = src.split(':').collect();
-
-        // At minimum, should be `spotify:user:{username}:{type}:{id}`
-        if uri_parts.len() < 5 {
-            return Err(SpotifyIdError::InvalidFormat.into());
-        }
-
-        if uri_parts[0] != "spotify" {
-            return Err(SpotifyIdError::InvalidRoot.into());
-        }
-
-        if uri_parts[1] != "user" {
-            return Err(SpotifyIdError::InvalidFormat.into());
-        }
-
-        Ok(Self {
-            inner_id: SpotifyId::from_uri(src)?,
-            username: uri_parts[2].to_owned(),
-        })
-    }
-
-    pub fn to_uri(&self) -> Result<String, Error> {
-        let item_type: &str = self.inner_id.item_type.into();
-        let mut dst = String::with_capacity(37 + self.username.len() + item_type.len());
-        dst.push_str("spotify:user:");
-        dst.push_str(&self.username);
-        dst.push(':');
-        dst.push_str(item_type);
-        dst.push(':');
-        let base_62 = self.to_base62()?;
-        dst.push_str(&base_62);
-
-        Ok(dst)
-    }
-
-    pub fn from_spotify_id(id: SpotifyId, username: &str) -> Self {
-        Self {
-            inner_id: id,
-            username: username.to_owned(),
-        }
-    }
-}
-
-impl Deref for NamedSpotifyId {
-    type Target = SpotifyId;
-    fn deref(&self) -> &Self::Target {
-        &self.inner_id
-    }
-}
-
-impl fmt::Debug for NamedSpotifyId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("NamedSpotifyId")
-            .field(
-                &self
-                    .inner_id
-                    .to_uri()
-                    .unwrap_or_else(|_| "invalid id".into()),
-            )
-            .finish()
-    }
-}
-
-impl fmt::Display for NamedSpotifyId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(
-            &self
-                .inner_id
-                .to_uri()
-                .unwrap_or_else(|_| "invalid id".into()),
-        )
+        f.write_str(&self.to_base62().unwrap_or_else(|_| "invalid uri".into()))
     }
 }
 
@@ -420,107 +243,6 @@ impl TryFrom<&Vec<u8>> for SpotifyId {
     type Error = crate::Error;
     fn try_from(src: &Vec<u8>) -> Result<Self, Self::Error> {
         Self::try_from(src.as_slice())
-    }
-}
-
-impl TryFrom<&protocol::metadata::Album> for SpotifyId {
-    type Error = crate::Error;
-    fn try_from(album: &protocol::metadata::Album) -> Result<Self, Self::Error> {
-        Ok(Self {
-            item_type: SpotifyItemType::Album,
-            ..Self::from_raw(album.gid())?
-        })
-    }
-}
-
-impl TryFrom<&protocol::metadata::Artist> for SpotifyId {
-    type Error = crate::Error;
-    fn try_from(artist: &protocol::metadata::Artist) -> Result<Self, Self::Error> {
-        Ok(Self {
-            item_type: SpotifyItemType::Artist,
-            ..Self::from_raw(artist.gid())?
-        })
-    }
-}
-
-impl TryFrom<&protocol::metadata::Episode> for SpotifyId {
-    type Error = crate::Error;
-    fn try_from(episode: &protocol::metadata::Episode) -> Result<Self, Self::Error> {
-        Ok(Self {
-            item_type: SpotifyItemType::Episode,
-            ..Self::from_raw(episode.gid())?
-        })
-    }
-}
-
-impl TryFrom<&protocol::metadata::Track> for SpotifyId {
-    type Error = crate::Error;
-    fn try_from(track: &protocol::metadata::Track) -> Result<Self, Self::Error> {
-        Ok(Self {
-            item_type: SpotifyItemType::Track,
-            ..Self::from_raw(track.gid())?
-        })
-    }
-}
-
-impl TryFrom<&protocol::metadata::Show> for SpotifyId {
-    type Error = crate::Error;
-    fn try_from(show: &protocol::metadata::Show) -> Result<Self, Self::Error> {
-        Ok(Self {
-            item_type: SpotifyItemType::Show,
-            ..Self::from_raw(show.gid())?
-        })
-    }
-}
-
-impl TryFrom<&protocol::metadata::ArtistWithRole> for SpotifyId {
-    type Error = crate::Error;
-    fn try_from(artist: &protocol::metadata::ArtistWithRole) -> Result<Self, Self::Error> {
-        Ok(Self {
-            item_type: SpotifyItemType::Artist,
-            ..Self::from_raw(artist.artist_gid())?
-        })
-    }
-}
-
-impl TryFrom<&protocol::playlist4_external::Item> for SpotifyId {
-    type Error = crate::Error;
-    fn try_from(item: &protocol::playlist4_external::Item) -> Result<Self, Self::Error> {
-        Ok(Self {
-            item_type: SpotifyItemType::Track,
-            ..Self::from_uri(item.uri())?
-        })
-    }
-}
-
-// Note that this is the unique revision of an item's metadata on a playlist,
-// not the ID of that item or playlist.
-impl TryFrom<&protocol::playlist4_external::MetaItem> for SpotifyId {
-    type Error = crate::Error;
-    fn try_from(item: &protocol::playlist4_external::MetaItem) -> Result<Self, Self::Error> {
-        Self::try_from(item.revision())
-    }
-}
-
-// Note that this is the unique revision of a playlist, not the ID of that playlist.
-impl TryFrom<&protocol::playlist4_external::SelectedListContent> for SpotifyId {
-    type Error = crate::Error;
-    fn try_from(
-        playlist: &protocol::playlist4_external::SelectedListContent,
-    ) -> Result<Self, Self::Error> {
-        Self::try_from(playlist.revision())
-    }
-}
-
-// TODO: check meaning and format of this field in the wild. This might be a FileId,
-// which is why we now don't create a separate `Playlist` enum value yet and choose
-// to discard any item type.
-impl TryFrom<&protocol::playlist_annotate3::TranscodedPicture> for SpotifyId {
-    type Error = crate::Error;
-    fn try_from(
-        picture: &protocol::playlist_annotate3::TranscodedPicture,
-    ) -> Result<Self, Self::Error> {
-        Self::from_base62(picture.uri())
     }
 }
 
@@ -679,10 +401,7 @@ mod tests {
     #[test]
     fn to_base62() {
         for c in &CONV_VALID {
-            let id = SpotifyId {
-                id: c.id,
-                item_type: c.kind,
-            };
+            let id = SpotifyId { id: c.id };
 
             assert_eq!(id.to_base62().unwrap(), c.base62);
         }
@@ -702,57 +421,9 @@ mod tests {
     #[test]
     fn to_base16() {
         for c in &CONV_VALID {
-            let id = SpotifyId {
-                id: c.id,
-                item_type: c.kind,
-            };
+            let id = SpotifyId { id: c.id };
 
             assert_eq!(id.to_base16().unwrap(), c.base16);
-        }
-    }
-
-    #[test]
-    fn from_uri() {
-        for c in &CONV_VALID {
-            let actual = SpotifyId::from_uri(c.uri).unwrap();
-
-            assert_eq!(actual.id, c.id);
-            assert_eq!(actual.item_type, c.kind);
-        }
-
-        for c in &CONV_INVALID {
-            assert!(SpotifyId::from_uri(c.uri).is_err());
-        }
-    }
-
-    #[test]
-    fn from_local_uri() {
-        let actual = SpotifyId::from_uri("spotify:local:xyz:123").unwrap();
-
-        assert_eq!(actual.id, 0);
-        assert_eq!(actual.item_type, SpotifyItemType::Local);
-    }
-
-    #[test]
-    fn from_named_uri() {
-        let actual =
-            NamedSpotifyId::from_uri("spotify:user:spotify:playlist:37i9dQZF1DWSw8liJZcPOI")
-                .unwrap();
-
-        assert_eq!(actual.id, 136159921382084734723401526672209703396);
-        assert_eq!(actual.item_type, SpotifyItemType::Playlist);
-        assert_eq!(actual.username, "spotify");
-    }
-
-    #[test]
-    fn to_uri() {
-        for c in &CONV_VALID {
-            let id = SpotifyId {
-                id: c.id,
-                item_type: c.kind,
-            };
-
-            assert_eq!(id.to_uri().unwrap(), c.uri);
         }
     }
 

--- a/core/src/spotify_uri.rs
+++ b/core/src/spotify_uri.rs
@@ -1,0 +1,321 @@
+use crate::spotify_id::SpotifyItemType;
+use crate::{Error, SpotifyId};
+use std::fmt;
+use thiserror::Error;
+
+use librespot_protocol as protocol;
+
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+pub enum SpotifyUriError {
+    #[error("not a valid Spotify URI")]
+    InvalidFormat,
+    #[error("URI does not belong to Spotify")]
+    InvalidRoot,
+}
+
+impl From<SpotifyUriError> for Error {
+    fn from(err: SpotifyUriError) -> Self {
+        Error::invalid_argument(err)
+    }
+}
+
+pub type SpotifyUriResult = Result<SpotifyUri, Error>;
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub enum SpotifyUri {
+    Album {
+        id: SpotifyId,
+    },
+    Artist {
+        id: SpotifyId,
+    },
+    Episode {
+        id: SpotifyId,
+    },
+    Playlist {
+        user: Option<String>,
+        id: SpotifyId,
+    },
+    Show {
+        id: SpotifyId,
+    },
+    Track {
+        id: SpotifyId,
+    },
+    Local {
+        artist: String,
+        album_title: String,
+        track_title: String,
+        duration: std::time::Duration,
+    },
+    Unknown {
+        id: SpotifyId,
+    },
+}
+
+impl SpotifyUri {
+    /// Returns whether this `SpotifyUri` is for a playable audio item, if known.
+    pub fn is_playable(&self) -> bool {
+        matches!(self, SpotifyUri::Episode { .. } | SpotifyUri::Track { .. })
+    }
+
+    pub fn item_type(&self) -> SpotifyItemType {
+        match &self {
+            SpotifyUri::Album { .. } => SpotifyItemType::Album,
+            SpotifyUri::Artist { .. } => SpotifyItemType::Artist,
+            SpotifyUri::Episode { .. } => SpotifyItemType::Episode,
+            SpotifyUri::Playlist { .. } => SpotifyItemType::Playlist,
+            SpotifyUri::Show { .. } => SpotifyItemType::Show,
+            SpotifyUri::Track { .. } => SpotifyItemType::Track,
+            SpotifyUri::Local { .. } => SpotifyItemType::Local,
+            SpotifyUri::Unknown { .. } => SpotifyItemType::Unknown,
+        }
+    }
+
+    pub fn to_name(&self) -> Result<String, Error> {
+        match &self {
+            SpotifyUri::Album { id }
+            | SpotifyUri::Artist { id }
+            | SpotifyUri::Episode { id }
+            | SpotifyUri::Playlist { id, user: None }
+            | SpotifyUri::Show { id }
+            | SpotifyUri::Track { id }
+            | SpotifyUri::Unknown { id } => id.to_base62(),
+            SpotifyUri::Local {
+                artist,
+                album_title,
+                track_title,
+                duration,
+            } => {
+                let duration_secs = duration.as_secs();
+                Ok(format!(
+                    "{artist}:{album_title}:{track_title}:{duration_secs}"
+                ))
+            }
+            SpotifyUri::Playlist {
+                id,
+                user: Some(user),
+            } => Ok(format!("{user}:{id}")),
+        }
+    }
+
+    /// Parses a [Spotify URI] into a `SpotifyUri`.
+    ///
+    /// `uri` is expected to be in the canonical form `spotify:{type}:{id}`, where `{type}`
+    /// can be arbitrary while `{id}` is a 22-character long, base62 encoded Spotify ID.
+    ///
+    /// Note that this should not be used for playlists, which have the form of
+    /// `spotify:playlist:{id}`.
+    ///
+    /// [Spotify URI]: https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids
+    pub fn from_uri(src: &str) -> SpotifyUriResult {
+        // Basic: `spotify:{type}:{id}`
+        // Named: `spotify:user:{user}:{type}:{id}`
+        // Local: `spotify:local:{artist}:{album_title}:{track_title}:{duration_in_seconds}`
+        let mut parts = src.split(':');
+
+        let scheme = parts.next().ok_or(SpotifyUriError::InvalidFormat)?;
+        let mut username: Option<String> = None;
+
+        let item_type = {
+            let next = parts.next().ok_or(SpotifyUriError::InvalidFormat)?;
+            if next == "user" {
+                username.replace(
+                    parts
+                        .next()
+                        .ok_or(SpotifyUriError::InvalidFormat)?
+                        .to_owned(),
+                );
+                parts.next().ok_or(SpotifyUriError::InvalidFormat)?
+            } else {
+                next
+            }
+        };
+
+        let name = parts.next().ok_or(SpotifyUriError::InvalidFormat)?;
+
+        if scheme != "spotify" {
+            return Err(SpotifyUriError::InvalidRoot.into());
+        }
+
+        let item_type = item_type.into();
+
+        match item_type {
+            SpotifyItemType::Album => Ok(Self::Album {
+                id: SpotifyId::from_base62(name)?,
+            }),
+            SpotifyItemType::Artist => Ok(Self::Artist {
+                id: SpotifyId::from_base62(name)?,
+            }),
+            SpotifyItemType::Episode => Ok(Self::Episode {
+                id: SpotifyId::from_base62(name)?,
+            }),
+            SpotifyItemType::Playlist => Ok(Self::Playlist {
+                id: SpotifyId::from_base62(name)?,
+                user: username,
+            }),
+            SpotifyItemType::Show => Ok(Self::Show {
+                id: SpotifyId::from_base62(name)?,
+            }),
+            SpotifyItemType::Track => Ok(Self::Track {
+                id: SpotifyId::from_base62(name)?,
+            }),
+            SpotifyItemType::Local => Ok(Self::Local {
+                artist: "unimplemented".to_owned(),
+                album_title: "unimplemented".to_owned(),
+                track_title: "unimplemented".to_owned(),
+                duration: Default::default(),
+            }),
+            SpotifyItemType::Unknown => Ok(Self::Unknown {
+                id: SpotifyId::from_base62(name)?,
+            }),
+        }
+    }
+
+    pub fn from_raw(src: &[u8], item_type: SpotifyItemType) -> SpotifyUriResult {
+        let id = SpotifyId::from_raw(src)?;
+
+        match item_type {
+            SpotifyItemType::Album => Ok(Self::Album { id }),
+            SpotifyItemType::Artist => Ok(Self::Artist { id }),
+            SpotifyItemType::Episode => Ok(Self::Episode { id }),
+            SpotifyItemType::Playlist => Ok(Self::Playlist { id, user: None }),
+            SpotifyItemType::Show => Ok(Self::Show { id }),
+            SpotifyItemType::Track => Ok(Self::Track { id }),
+            SpotifyItemType::Unknown => Ok(Self::Unknown { id }),
+            SpotifyItemType::Local => Err(SpotifyUriError::InvalidFormat.into()),
+        }
+    }
+
+    /// Returns the `SpotifyUri` as a [Spotify URI] in the canonical form `spotify:{type}:{id}`,
+    /// where `{type}` is an arbitrary string and `{id}` is a 22-character long, base62 encoded
+    /// Spotify ID.
+    ///
+    /// If the `SpotifyUri` has an associated type unrecognized by the library, `{type}` will
+    /// be encoded as `unknown`.
+    ///
+    /// [Spotify URI]: https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids
+    pub fn to_uri(&self) -> Result<String, Error> {
+        let item_type: &str = self.item_type().into();
+        let name = self.to_name()?;
+
+        Ok(format!("spotify:{item_type}:{name}"))
+    }
+
+    #[deprecated(since = "0.7.0", note = "use to_name instead")]
+    pub fn to_base62(&self) -> Result<String, Error> {
+        self.to_name()
+    }
+}
+
+impl From<SpotifyId> for SpotifyUri {
+    fn from(id: SpotifyId) -> Self {
+        Self::Unknown { id }
+    }
+}
+
+impl fmt::Debug for SpotifyUri {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("SpotifyUri")
+            .field(&self.to_uri().unwrap_or_else(|_| "invalid uri".into()))
+            .finish()
+    }
+}
+
+impl TryFrom<&protocol::metadata::Album> for SpotifyUri {
+    type Error = crate::Error;
+    fn try_from(album: &protocol::metadata::Album) -> Result<Self, Self::Error> {
+        Ok(Self::Album {
+            id: SpotifyId::from_raw(album.gid())?,
+        })
+    }
+}
+
+impl TryFrom<&protocol::metadata::Artist> for SpotifyUri {
+    type Error = crate::Error;
+    fn try_from(artist: &protocol::metadata::Artist) -> Result<Self, Self::Error> {
+        Ok(Self::Artist {
+            id: SpotifyId::from_raw(artist.gid())?,
+        })
+    }
+}
+
+impl TryFrom<&protocol::metadata::Episode> for SpotifyUri {
+    type Error = crate::Error;
+    fn try_from(episode: &protocol::metadata::Episode) -> Result<Self, Self::Error> {
+        Ok(Self::Episode {
+            id: SpotifyId::from_raw(episode.gid())?,
+        })
+    }
+}
+
+impl TryFrom<&protocol::metadata::Track> for SpotifyUri {
+    type Error = crate::Error;
+    fn try_from(track: &protocol::metadata::Track) -> Result<Self, Self::Error> {
+        Ok(Self::Track {
+            id: SpotifyId::from_raw(track.gid())?,
+        })
+    }
+}
+
+impl TryFrom<&protocol::metadata::Show> for SpotifyUri {
+    type Error = crate::Error;
+    fn try_from(show: &protocol::metadata::Show) -> Result<Self, Self::Error> {
+        Ok(Self::Show {
+            id: SpotifyId::from_raw(show.gid())?,
+        })
+    }
+}
+
+impl TryFrom<&protocol::metadata::ArtistWithRole> for SpotifyUri {
+    type Error = crate::Error;
+    fn try_from(artist: &protocol::metadata::ArtistWithRole) -> Result<Self, Self::Error> {
+        Ok(Self::Artist {
+            id: SpotifyId::from_raw(artist.artist_gid())?,
+        })
+    }
+}
+
+impl TryFrom<&protocol::playlist4_external::Item> for SpotifyUri {
+    type Error = crate::Error;
+    fn try_from(item: &protocol::playlist4_external::Item) -> Result<Self, Self::Error> {
+        Self::from_uri(item.uri())
+    }
+}
+
+// Note that this is the unique revision of an item's metadata on a playlist,
+// not the ID of that item or playlist.
+impl TryFrom<&protocol::playlist4_external::MetaItem> for SpotifyUri {
+    type Error = crate::Error;
+    fn try_from(item: &protocol::playlist4_external::MetaItem) -> Result<Self, Self::Error> {
+        Ok(Self::Unknown {
+            id: SpotifyId::try_from(item.revision())?,
+        })
+    }
+}
+
+// Note that this is the unique revision of a playlist, not the ID of that playlist.
+impl TryFrom<&protocol::playlist4_external::SelectedListContent> for SpotifyUri {
+    type Error = crate::Error;
+    fn try_from(
+        playlist: &protocol::playlist4_external::SelectedListContent,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self::Unknown {
+            id: SpotifyId::try_from(playlist.revision())?,
+        })
+    }
+}
+
+// TODO: check meaning and format of this field in the wild. This might be a FileId,
+// which is why we now don't create a separate `Playlist` enum value yet and choose
+// to discard any item type.
+impl TryFrom<&protocol::playlist_annotate3::TranscodedPicture> for SpotifyUri {
+    type Error = crate::Error;
+    fn try_from(
+        picture: &protocol::playlist_annotate3::TranscodedPicture,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self::Unknown {
+            id: SpotifyId::from_base62(picture.uri())?,
+        })
+    }
+}

--- a/examples/play.rs
+++ b/examples/play.rs
@@ -2,10 +2,11 @@ use std::{env, process::exit};
 
 use librespot::{
     core::{
+        SpotifyUri,
         authentication::Credentials,
         config::SessionConfig,
         session::Session,
-        spotify_id::{SpotifyId, SpotifyItemType},
+        spotify_id::{SpotifyId},
     },
     playback::{
         audio_backend,
@@ -28,8 +29,9 @@ async fn main() {
     }
     let credentials = Credentials::with_access_token(&args[1]);
 
-    let mut track = SpotifyId::from_base62(&args[2]).unwrap();
-    track.item_type = SpotifyItemType::Track;
+    let track = SpotifyUri::Track {
+        id: SpotifyId::from_base62(&args[2]).unwrap(),
+    };
 
     let backend = audio_backend::find(None).unwrap();
 
@@ -44,7 +46,7 @@ async fn main() {
         backend(None, audio_format)
     });
 
-    player.load(track, true, 0);
+    player.load_uri(track, true, 0);
 
     println!("Playing...");
 

--- a/examples/playlist_tracks.rs
+++ b/examples/playlist_tracks.rs
@@ -2,7 +2,8 @@ use std::{env, process::exit};
 
 use librespot::{
     core::{
-        authentication::Credentials, config::SessionConfig, session::Session, spotify_id::SpotifyId,
+        authentication::Credentials, config::SessionConfig, session::Session,
+        spotify_uri::SpotifyUri,
     },
     metadata::{Metadata, Playlist, Track},
 };
@@ -19,7 +20,7 @@ async fn main() {
     }
     let credentials = Credentials::with_access_token(&args[1]);
 
-    let plist_uri = SpotifyId::from_uri(&args[2]).unwrap_or_else(|_| {
+    let plist_uri = SpotifyUri::from_uri(&args[2]).unwrap_or_else(|_| {
         eprintln!(
             "PLAYLIST should be a playlist URI such as: \
                 \"spotify:playlist:37i9dQZF1DXec50AjHrNTq\""

--- a/metadata/src/album.rs
+++ b/metadata/src/album.rs
@@ -17,7 +17,7 @@ use crate::{
     util::{impl_deref_wrapped, impl_try_from_repeated},
 };
 
-use librespot_core::{Error, Session, SpotifyId, date::Date};
+use librespot_core::{Error, Session, SpotifyUri, date::Date};
 
 use librespot_protocol as protocol;
 use protocol::metadata::Disc as DiscMessage;
@@ -25,7 +25,7 @@ pub use protocol::metadata::album::Type as AlbumType;
 
 #[derive(Debug, Clone)]
 pub struct Album {
-    pub id: SpotifyId,
+    pub id: SpotifyUri,
     pub name: String,
     pub artists: Artists,
     pub album_type: AlbumType,
@@ -48,9 +48,9 @@ pub struct Album {
 }
 
 #[derive(Debug, Clone, Default)]
-pub struct Albums(pub Vec<SpotifyId>);
+pub struct Albums(pub Vec<SpotifyUri>);
 
-impl_deref_wrapped!(Albums, Vec<SpotifyId>);
+impl_deref_wrapped!(Albums, Vec<SpotifyUri>);
 
 #[derive(Debug, Clone)]
 pub struct Disc {
@@ -65,7 +65,7 @@ pub struct Discs(pub Vec<Disc>);
 impl_deref_wrapped!(Discs, Vec<Disc>);
 
 impl Album {
-    pub fn tracks(&self) -> impl Iterator<Item = &SpotifyId> {
+    pub fn tracks(&self) -> impl Iterator<Item = &SpotifyUri> {
         self.discs.iter().flat_map(|disc| disc.tracks.iter())
     }
 }
@@ -74,11 +74,15 @@ impl Album {
 impl Metadata for Album {
     type Message = protocol::metadata::Album;
 
-    async fn request(session: &Session, album_id: &SpotifyId) -> RequestResult {
-        session.spclient().get_album_metadata(album_id).await
+    async fn request(session: &Session, album_uri: &SpotifyUri) -> RequestResult {
+        let SpotifyUri::Album { id: album_id } = album_uri else {
+            return Err(Error::invalid_argument("album_uri"));
+        };
+
+        session.spclient().get_album_metadata(&album_id).await
     }
 
-    fn parse(msg: &Self::Message, _: &SpotifyId) -> Result<Self, Error> {
+    fn parse(msg: &Self::Message, _: &SpotifyUri) -> Result<Self, Error> {
         Self::try_from(msg)
     }
 }

--- a/metadata/src/artist.rs
+++ b/metadata/src/artist.rs
@@ -16,7 +16,7 @@ use crate::{
     util::{impl_deref_wrapped, impl_from_repeated, impl_try_from_repeated},
 };
 
-use librespot_core::{Error, Session, SpotifyId};
+use librespot_core::{Error, Session, SpotifyUri};
 
 use librespot_protocol as protocol;
 pub use protocol::metadata::artist_with_role::ArtistRole;
@@ -29,7 +29,7 @@ use protocol::metadata::TopTracks as TopTracksMessage;
 
 #[derive(Debug, Clone)]
 pub struct Artist {
-    pub id: SpotifyId,
+    pub id: SpotifyUri,
     pub name: String,
     pub popularity: i32,
     pub top_tracks: CountryTopTracks,
@@ -56,7 +56,7 @@ impl_deref_wrapped!(Artists, Vec<Artist>);
 
 #[derive(Debug, Clone)]
 pub struct ArtistWithRole {
-    pub id: SpotifyId,
+    pub id: SpotifyUri,
     pub name: String,
     pub role: ArtistRole,
 }
@@ -140,14 +140,14 @@ impl Artist {
     /// Get the full list of albums, not containing duplicate variants of the same albums.
     ///
     /// See also [`AlbumGroups`](struct@AlbumGroups) and [`AlbumGroups::current_releases`]
-    pub fn albums_current(&self) -> impl Iterator<Item = &SpotifyId> {
+    pub fn albums_current(&self) -> impl Iterator<Item = &SpotifyUri> {
         self.albums.current_releases()
     }
 
     /// Get the full list of singles, not containing duplicate variants of the same singles.
     ///
     /// See also [`AlbumGroups`](struct@AlbumGroups) and [`AlbumGroups::current_releases`]
-    pub fn singles_current(&self) -> impl Iterator<Item = &SpotifyId> {
+    pub fn singles_current(&self) -> impl Iterator<Item = &SpotifyUri> {
         self.singles.current_releases()
     }
 
@@ -155,14 +155,14 @@ impl Artist {
     /// compilations.
     ///
     /// See also [`AlbumGroups`](struct@AlbumGroups) and [`AlbumGroups::current_releases`]
-    pub fn compilations_current(&self) -> impl Iterator<Item = &SpotifyId> {
+    pub fn compilations_current(&self) -> impl Iterator<Item = &SpotifyUri> {
         self.compilations.current_releases()
     }
 
     /// Get the full list of albums, not containing duplicate variants of the same albums.
     ///
     /// See also [`AlbumGroups`](struct@AlbumGroups) and [`AlbumGroups::current_releases`]
-    pub fn appears_on_albums_current(&self) -> impl Iterator<Item = &SpotifyId> {
+    pub fn appears_on_albums_current(&self) -> impl Iterator<Item = &SpotifyUri> {
         self.appears_on_albums.current_releases()
     }
 }
@@ -171,11 +171,15 @@ impl Artist {
 impl Metadata for Artist {
     type Message = protocol::metadata::Artist;
 
-    async fn request(session: &Session, artist_id: &SpotifyId) -> RequestResult {
-        session.spclient().get_artist_metadata(artist_id).await
+    async fn request(session: &Session, artist_uri: &SpotifyUri) -> RequestResult {
+        let SpotifyUri::Artist { id: artist_id } = artist_uri else {
+            return Err(Error::invalid_argument("artist_uri"));
+        };
+
+        session.spclient().get_artist_metadata(&artist_id).await
     }
 
-    fn parse(msg: &Self::Message, _: &SpotifyId) -> Result<Self, Error> {
+    fn parse(msg: &Self::Message, _: &SpotifyUri) -> Result<Self, Error> {
         Self::try_from(msg)
     }
 }
@@ -249,7 +253,7 @@ impl AlbumGroups {
     /// Get the contained albums. This will only use the latest release / variant of an album if
     /// multiple variants are available. This should be used if multiple variants of the same album
     /// are not explicitely desired.
-    pub fn current_releases(&self) -> impl Iterator<Item = &SpotifyId> {
+    pub fn current_releases(&self) -> impl Iterator<Item = &SpotifyUri> {
         self.iter().filter_map(|agrp| agrp.first())
     }
 }

--- a/metadata/src/episode.rs
+++ b/metadata/src/episode.rs
@@ -15,14 +15,14 @@ use crate::{
     video::VideoFiles,
 };
 
-use librespot_core::{Error, Session, SpotifyId, date::Date};
+use librespot_core::{Error, Session, SpotifyUri, date::Date};
 
 use librespot_protocol as protocol;
 pub use protocol::metadata::episode::EpisodeType;
 
 #[derive(Debug, Clone)]
 pub struct Episode {
-    pub id: SpotifyId,
+    pub id: SpotifyUri,
     pub name: String,
     pub duration: i32,
     pub audio: AudioFiles,
@@ -49,19 +49,23 @@ pub struct Episode {
 }
 
 #[derive(Debug, Clone, Default)]
-pub struct Episodes(pub Vec<SpotifyId>);
+pub struct Episodes(pub Vec<SpotifyUri>);
 
-impl_deref_wrapped!(Episodes, Vec<SpotifyId>);
+impl_deref_wrapped!(Episodes, Vec<SpotifyUri>);
 
 #[async_trait]
 impl Metadata for Episode {
     type Message = protocol::metadata::Episode;
 
-    async fn request(session: &Session, episode_id: &SpotifyId) -> RequestResult {
-        session.spclient().get_episode_metadata(episode_id).await
+    async fn request(session: &Session, episode_uri: &SpotifyUri) -> RequestResult {
+        let SpotifyUri::Episode { id: episode_id } = episode_uri else {
+            return Err(Error::invalid_argument("episode_uri"));
+        };
+
+        session.spclient().get_episode_metadata(&episode_id).await
     }
 
-    fn parse(msg: &Self::Message, _: &SpotifyId) -> Result<Self, Error> {
+    fn parse(msg: &Self::Message, _: &SpotifyUri) -> Result<Self, Error> {
         Self::try_from(msg)
     }
 }

--- a/metadata/src/image.rs
+++ b/metadata/src/image.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::util::{impl_deref_wrapped, impl_from_repeated, impl_try_from_repeated};
 
-use librespot_core::{FileId, SpotifyId};
+use librespot_core::{FileId, SpotifyUri};
 
 use librespot_protocol as protocol;
 use protocol::metadata::Image as ImageMessage;
@@ -47,7 +47,7 @@ impl_deref_wrapped!(PictureSizes, Vec<PictureSize>);
 #[derive(Debug, Clone)]
 pub struct TranscodedPicture {
     pub target_name: String,
-    pub uri: SpotifyId,
+    pub uri: SpotifyUri,
 }
 
 #[derive(Debug, Clone)]

--- a/metadata/src/lib.rs
+++ b/metadata/src/lib.rs
@@ -6,7 +6,7 @@ extern crate async_trait;
 
 use protobuf::Message;
 
-use librespot_core::{Error, Session, SpotifyId};
+use librespot_core::{Error, Session, SpotifyUri};
 
 pub mod album;
 pub mod artist;
@@ -44,15 +44,15 @@ pub trait Metadata: Send + Sized + 'static {
     type Message: protobuf::Message + std::fmt::Debug;
 
     // Request a protobuf
-    async fn request(session: &Session, id: &SpotifyId) -> RequestResult;
+    async fn request(session: &Session, id: &SpotifyUri) -> RequestResult;
 
     // Request a metadata struct
-    async fn get(session: &Session, id: &SpotifyId) -> Result<Self, Error> {
+    async fn get(session: &Session, id: &SpotifyUri) -> Result<Self, Error> {
         let response = Self::request(session, id).await?;
         let msg = Self::Message::parse_from_bytes(&response)?;
         trace!("Received metadata: {msg:#?}");
         Self::parse(&msg, id)
     }
 
-    fn parse(msg: &Self::Message, _: &SpotifyId) -> Result<Self, Error>;
+    fn parse(msg: &Self::Message, _: &SpotifyUri) -> Result<Self, Error>;
 }

--- a/metadata/src/playlist/annotation.rs
+++ b/metadata/src/playlist/annotation.rs
@@ -8,8 +8,7 @@ use crate::{
     request::{MercuryRequest, RequestResult},
 };
 
-use librespot_core::{Error, Session, SpotifyId};
-
+use librespot_core::{Error, Session, SpotifyId, SpotifyUri};
 use librespot_protocol as protocol;
 pub use protocol::playlist_annotate3::AbuseReportState;
 
@@ -26,12 +25,20 @@ pub struct PlaylistAnnotation {
 impl Metadata for PlaylistAnnotation {
     type Message = protocol::playlist_annotate3::PlaylistAnnotation;
 
-    async fn request(session: &Session, playlist_id: &SpotifyId) -> RequestResult {
+    async fn request(session: &Session, playlist_uri: &SpotifyUri) -> RequestResult {
         let current_user = session.username();
-        Self::request_for_user(session, &current_user, playlist_id).await
+
+        let SpotifyUri::Playlist {
+            id: playlist_id, ..
+        } = playlist_uri
+        else {
+            return Err(Error::invalid_argument("playlist_uri"));
+        };
+
+        Self::request_for_user(session, &current_user, &playlist_id).await
     }
 
-    fn parse(msg: &Self::Message, _: &SpotifyId) -> Result<Self, Error> {
+    fn parse(msg: &Self::Message, _: &SpotifyUri) -> Result<Self, Error> {
         Ok(Self {
             description: msg.description().to_owned(),
             picture: msg.picture().to_owned(), // TODO: is this a URL or Spotify URI?
@@ -60,11 +67,18 @@ impl PlaylistAnnotation {
     async fn get_for_user(
         session: &Session,
         username: &str,
-        playlist_id: &SpotifyId,
+        playlist_uri: &SpotifyUri,
     ) -> Result<Self, Error> {
-        let response = Self::request_for_user(session, username, playlist_id).await?;
+        let SpotifyUri::Playlist {
+            id: playlist_id, ..
+        } = playlist_uri
+        else {
+            return Err(Error::invalid_argument("playlist_uri"));
+        };
+
+        let response = Self::request_for_user(session, username, &playlist_id).await?;
         let msg = <Self as Metadata>::Message::parse_from_bytes(&response)?;
-        Self::parse(&msg, playlist_id)
+        Self::parse(&msg, playlist_uri)
     }
 }
 

--- a/metadata/src/playlist/item.rs
+++ b/metadata/src/playlist/item.rs
@@ -10,7 +10,7 @@ use super::{
     permission::Capabilities,
 };
 
-use librespot_core::{SpotifyId, date::Date};
+use librespot_core::{SpotifyUri, date::Date};
 
 use librespot_protocol as protocol;
 use protocol::playlist4_external::Item as PlaylistItemMessage;
@@ -19,7 +19,7 @@ use protocol::playlist4_external::MetaItem as PlaylistMetaItemMessage;
 
 #[derive(Debug, Clone)]
 pub struct PlaylistItem {
-    pub id: SpotifyId,
+    pub id: SpotifyUri,
     pub attributes: PlaylistItemAttributes,
 }
 
@@ -38,7 +38,7 @@ pub struct PlaylistItemList {
 
 #[derive(Debug, Clone)]
 pub struct PlaylistMetaItem {
-    pub revision: SpotifyId,
+    pub revision: SpotifyUri,
     pub attributes: PlaylistAttributes,
     pub length: i32,
     pub timestamp: Date,

--- a/metadata/src/playlist/list.rs
+++ b/metadata/src/playlist/list.rs
@@ -14,12 +14,7 @@ use super::{
     permission::Capabilities,
 };
 
-use librespot_core::{
-    Error, Session,
-    date::Date,
-    spotify_id::{NamedSpotifyId, SpotifyId},
-};
-
+use librespot_core::{Error, Session, SpotifyUri, date::Date, spotify_id::SpotifyId};
 use librespot_protocol as protocol;
 use protocol::playlist4_external::GeoblockBlockingType as Geoblock;
 
@@ -30,7 +25,7 @@ impl_deref_wrapped!(Geoblocks, Vec<Geoblock>);
 
 #[derive(Debug, Clone)]
 pub struct Playlist {
-    pub id: NamedSpotifyId,
+    pub id: SpotifyUri,
     pub revision: Vec<u8>,
     pub length: i32,
     pub attributes: PlaylistAttributes,
@@ -72,7 +67,7 @@ pub struct SelectedListContent {
 }
 
 impl Playlist {
-    pub fn tracks(&self) -> impl ExactSizeIterator<Item = &SpotifyId> {
+    pub fn tracks(&self) -> impl ExactSizeIterator<Item = &SpotifyUri> {
         let tracks = self.contents.items.iter().map(|item| &item.id);
 
         let length = tracks.len();
@@ -93,17 +88,35 @@ impl Playlist {
 impl Metadata for Playlist {
     type Message = protocol::playlist4_external::SelectedListContent;
 
-    async fn request(session: &Session, playlist_id: &SpotifyId) -> RequestResult {
-        session.spclient().get_playlist(playlist_id).await
+    async fn request(session: &Session, playlist_uri: &SpotifyUri) -> RequestResult {
+        let SpotifyUri::Playlist {
+            id: playlist_id, ..
+        } = playlist_uri
+        else {
+            return Err(Error::invalid_argument("playlist_uri"));
+        };
+
+        session.spclient().get_playlist(&playlist_id).await
     }
 
-    fn parse(msg: &Self::Message, id: &SpotifyId) -> Result<Self, Error> {
+    fn parse(msg: &Self::Message, uri: &SpotifyUri) -> Result<Self, Error> {
+        let SpotifyUri::Playlist {
+            id: playlist_id, ..
+        } = uri
+        else {
+            return Err(Error::invalid_argument("playlist_uri"));
+        };
+
         // the playlist proto doesn't contain the id so we decorate it
         let playlist = SelectedListContent::try_from(msg)?;
-        let id = NamedSpotifyId::from_spotify_id(*id, &playlist.owner_username);
+
+        let new_uri = SpotifyUri::Playlist {
+            id: *playlist_id,
+            user: Some(playlist.owner_username),
+        };
 
         Ok(Self {
-            id,
+            id: new_uri,
             revision: playlist.revision,
             length: playlist.length,
             attributes: playlist.attributes,

--- a/metadata/src/show.rs
+++ b/metadata/src/show.rs
@@ -5,7 +5,7 @@ use crate::{
     episode::Episodes, image::Images, restriction::Restrictions,
 };
 
-use librespot_core::{Error, Session, SpotifyId};
+use librespot_core::{Error, Session,  SpotifyUri};
 
 use librespot_protocol as protocol;
 pub use protocol::metadata::show::ConsumptionOrder as ShowConsumptionOrder;
@@ -13,7 +13,7 @@ pub use protocol::metadata::show::MediaType as ShowMediaType;
 
 #[derive(Debug, Clone)]
 pub struct Show {
-    pub id: SpotifyId,
+    pub id: SpotifyUri,
     pub name: String,
     pub description: String,
     pub publisher: String,
@@ -27,7 +27,7 @@ pub struct Show {
     pub media_type: ShowMediaType,
     pub consumption_order: ShowConsumptionOrder,
     pub availability: Availabilities,
-    pub trailer_uri: Option<SpotifyId>,
+    pub trailer_uri: Option<SpotifyUri>,
     pub has_music_and_talk: bool,
     pub is_audiobook: bool,
 }
@@ -36,11 +36,15 @@ pub struct Show {
 impl Metadata for Show {
     type Message = protocol::metadata::Show;
 
-    async fn request(session: &Session, show_id: &SpotifyId) -> RequestResult {
-        session.spclient().get_show_metadata(show_id).await
+    async fn request(session: &Session, show_uri: &SpotifyUri) -> RequestResult {
+        let SpotifyUri::Show { id: show_id } = show_uri else {
+            return Err(Error::invalid_argument("show_uri"));
+        };
+        
+        session.spclient().get_show_metadata(&show_id).await
     }
 
-    fn parse(msg: &Self::Message, _: &SpotifyId) -> Result<Self, Error> {
+    fn parse(msg: &Self::Message, _: &SpotifyUri) -> Result<Self, Error> {
         Self::try_from(msg)
     }
 }
@@ -67,7 +71,7 @@ impl TryFrom<&<Self as Metadata>::Message> for Show {
                 .trailer_uri
                 .as_deref()
                 .filter(|s| !s.is_empty())
-                .map(SpotifyId::from_uri)
+                .map(SpotifyUri::from_uri)
                 .transpose()?,
             has_music_and_talk: show.music_and_talk(),
             is_audiobook: show.is_audiobook(),

--- a/metadata/src/track.rs
+++ b/metadata/src/track.rs
@@ -17,12 +17,12 @@ use crate::{
     util::{impl_deref_wrapped, impl_try_from_repeated},
 };
 
-use librespot_core::{Error, Session, SpotifyId, date::Date};
+use librespot_core::{Error, Session, SpotifyUri, date::Date};
 use librespot_protocol as protocol;
 
 #[derive(Debug, Clone)]
 pub struct Track {
-    pub id: SpotifyId,
+    pub id: SpotifyUri,
     pub name: String,
     pub album: Album,
     pub artists: Artists,
@@ -50,19 +50,23 @@ pub struct Track {
 }
 
 #[derive(Debug, Clone, Default)]
-pub struct Tracks(pub Vec<SpotifyId>);
+pub struct Tracks(pub Vec<SpotifyUri>);
 
-impl_deref_wrapped!(Tracks, Vec<SpotifyId>);
+impl_deref_wrapped!(Tracks, Vec<SpotifyUri>);
 
 #[async_trait]
 impl Metadata for Track {
     type Message = protocol::metadata::Track;
 
-    async fn request(session: &Session, track_id: &SpotifyId) -> RequestResult {
-        session.spclient().get_track_metadata(track_id).await
+    async fn request(session: &Session, track_uri: &SpotifyUri) -> RequestResult {
+        let SpotifyUri::Track { id: track_id } = track_uri else {
+            return Err(Error::invalid_argument("track_uri"));
+        };
+
+        session.spclient().get_track_metadata(&track_id).await
     }
 
-    fn parse(msg: &Self::Message, _: &SpotifyId) -> Result<Self, Error> {
+    fn parse(msg: &Self::Message, _: &SpotifyUri) -> Result<Self, Error> {
         Self::try_from(msg)
     }
 }

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -15,27 +15,26 @@ use std::{
     time::{Duration, Instant},
 };
 
-use futures_util::{
-    StreamExt, TryFutureExt, future, future::FusedFuture,
-    stream::futures_unordered::FuturesUnordered,
-};
-use parking_lot::Mutex;
-use symphonia::core::io::MediaSource;
-use tokio::sync::{mpsc, oneshot};
-
+#[cfg(feature = "passthrough-decoder")]
+use crate::decoder::PassthroughDecoder;
 use crate::{
     audio::{AudioDecrypt, AudioFetchParams, AudioFile, StreamLoaderController},
     audio_backend::Sink,
     config::{Bitrate, NormalisationMethod, NormalisationType, PlayerConfig},
     convert::Converter,
-    core::{Error, Session, SpotifyId, util::SeqGenerator},
+    core::{Error, Session, SpotifyId, SpotifyUri, util::SeqGenerator},
     decoder::{AudioDecoder, AudioPacket, AudioPacketPosition, SymphoniaDecoder},
     metadata::audio::{AudioFileFormat, AudioFiles, AudioItem},
     mixer::VolumeGetter,
 };
-
-#[cfg(feature = "passthrough-decoder")]
-use crate::decoder::PassthroughDecoder;
+use futures_util::{
+    StreamExt, TryFutureExt, future, future::FusedFuture,
+    stream::futures_unordered::FuturesUnordered,
+};
+use librespot_metadata::track::Tracks;
+use parking_lot::Mutex;
+use symphonia::core::io::MediaSource;
+use tokio::sync::{mpsc, oneshot};
 
 use crate::SAMPLES_PER_SECOND;
 
@@ -94,12 +93,12 @@ static PLAYER_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
 enum PlayerCommand {
     Load {
-        track_id: SpotifyId,
+        track_id: SpotifyUri,
         play: bool,
         position_ms: u32,
     },
     Preload {
-        track_id: SpotifyId,
+        track_id: SpotifyUri,
     },
     Play,
     Pause,
@@ -142,17 +141,17 @@ pub enum PlayerEvent {
     // Fired when the player is stopped (e.g. by issuing a "stop" command to the player).
     Stopped {
         play_request_id: u64,
-        track_id: SpotifyId,
+        track_id: SpotifyUri,
     },
     // The player is delayed by loading a track.
     Loading {
         play_request_id: u64,
-        track_id: SpotifyId,
+        track_id: SpotifyUri,
         position_ms: u32,
     },
     // The player is preloading a track.
     Preloading {
-        track_id: SpotifyId,
+        track_id: SpotifyUri,
     },
     // The player is playing a track.
     // This event is issued at the start of playback of whenever the position must be communicated
@@ -163,31 +162,31 @@ pub enum PlayerEvent {
     // after a buffer-underrun
     Playing {
         play_request_id: u64,
-        track_id: SpotifyId,
+        track_id: SpotifyUri,
         position_ms: u32,
     },
     // The player entered a paused state.
     Paused {
         play_request_id: u64,
-        track_id: SpotifyId,
+        track_id: SpotifyUri,
         position_ms: u32,
     },
     // The player thinks it's a good idea to issue a preload command for the next track now.
     // This event is intended for use within spirc.
     TimeToPreloadNextTrack {
         play_request_id: u64,
-        track_id: SpotifyId,
+        track_id: SpotifyUri,
     },
     // The player reached the end of a track.
     // This event is intended for use within spirc. Spirc will respond by issuing another command.
     EndOfTrack {
         play_request_id: u64,
-        track_id: SpotifyId,
+        track_id: SpotifyUri,
     },
     // The player was unable to load the requested track.
     Unavailable {
         play_request_id: u64,
-        track_id: SpotifyId,
+        track_id: SpotifyUri,
     },
     // The mixer volume was set to a new level.
     VolumeChanged {
@@ -195,7 +194,7 @@ pub enum PlayerEvent {
     },
     PositionCorrection {
         play_request_id: u64,
-        track_id: SpotifyId,
+        track_id: SpotifyUri,
         position_ms: u32,
     },
     /// Requires `PlayerConfig::position_update_interval` to be set to Some.
@@ -203,12 +202,12 @@ pub enum PlayerEvent {
     /// current playback position
     PositionChanged {
         play_request_id: u64,
-        track_id: SpotifyId,
+        track_id: SpotifyUri,
         position_ms: u32,
     },
     Seeked {
         play_request_id: u64,
-        track_id: SpotifyId,
+        track_id: SpotifyUri,
         position_ms: u32,
     },
     TrackChanged {
@@ -526,7 +525,16 @@ impl Player {
         }
     }
 
+    #[deprecated(since = "0.7.0", note = "use load_uri instead")]
     pub fn load(&self, track_id: SpotifyId, start_playing: bool, position_ms: u32) {
+        self.command(PlayerCommand::Load {
+            track_id: track_id.into(),
+            play: start_playing,
+            position_ms,
+        });
+    }
+
+    pub fn load_uri(&self, track_id: SpotifyUri, start_playing: bool, position_ms: u32) {
         self.command(PlayerCommand::Load {
             track_id,
             play: start_playing,
@@ -534,7 +542,14 @@ impl Player {
         });
     }
 
+    #[deprecated(since = "0.7.0", note = "use preload_uri instead")]
     pub fn preload(&self, track_id: SpotifyId) {
+        self.command(PlayerCommand::Preload {
+            track_id: track_id.into(),
+        });
+    }
+
+    pub fn preload_uri(&self, track_id: SpotifyUri) {
         self.command(PlayerCommand::Preload { track_id });
     }
 
@@ -660,11 +675,11 @@ struct PlayerLoadedTrackData {
 enum PlayerPreload {
     None,
     Loading {
-        track_id: SpotifyId,
+        track_id: SpotifyUri,
         loader: Pin<Box<dyn FusedFuture<Output = Result<PlayerLoadedTrackData, ()>> + Send>>,
     },
     Ready {
-        track_id: SpotifyId,
+        track_id: SpotifyUri,
         loaded_track: Box<PlayerLoadedTrackData>,
     },
 }
@@ -674,13 +689,13 @@ type Decoder = Box<dyn AudioDecoder + Send>;
 enum PlayerState {
     Stopped,
     Loading {
-        track_id: SpotifyId,
+        track_id: SpotifyUri,
         play_request_id: u64,
         start_playback: bool,
         loader: Pin<Box<dyn FusedFuture<Output = Result<PlayerLoadedTrackData, ()>> + Send>>,
     },
     Paused {
-        track_id: SpotifyId,
+        track_id: SpotifyUri,
         play_request_id: u64,
         decoder: Decoder,
         audio_item: AudioItem,
@@ -694,7 +709,7 @@ enum PlayerState {
         is_explicit: bool,
     },
     Playing {
-        track_id: SpotifyId,
+        track_id: SpotifyUri,
         play_request_id: u64,
         decoder: Decoder,
         normalisation_data: NormalisationData,
@@ -709,7 +724,7 @@ enum PlayerState {
         is_explicit: bool,
     },
     EndOfTrack {
-        track_id: SpotifyId,
+        track_id: SpotifyUri,
         play_request_id: u64,
         loaded_track: PlayerLoadedTrackData,
     },
@@ -893,10 +908,12 @@ impl PlayerTrackLoader {
             None
         } else if !audio_item.files.is_empty() {
             Some(audio_item)
-        } else if let Some(alternatives) = &audio_item.alternatives {
-            let alternatives: FuturesUnordered<_> = alternatives
-                .iter()
-                .map(|alt_id| AudioItem::get_file(&self.session, *alt_id))
+        } else if let Some(alternatives) = audio_item.alternatives {
+            let Tracks(alternatives_vec) = alternatives; // required to make `into_iter` able to move
+
+            let alternatives: FuturesUnordered<_> = alternatives_vec
+                .into_iter()
+                .map(|alt_id| AudioItem::get_file(&self.session, alt_id))
                 .collect();
 
             alternatives
@@ -938,16 +955,34 @@ impl PlayerTrackLoader {
 
     async fn load_track(
         &self,
-        spotify_id: SpotifyId,
+        track_uri: SpotifyUri,
         position_ms: u32,
     ) -> Option<PlayerLoadedTrackData> {
-        let audio_item = match AudioItem::get_file(&self.session, spotify_id).await {
+        match track_uri {
+            SpotifyUri::Track { id: track_id } => {
+                self.load_remote_track(track_uri, track_id, position_ms)
+                    .await
+            }
+            _ => {
+                error!("Cannot handle load of track with URI: <{track_uri:?}>",);
+                None
+            }
+        }
+    }
+
+    async fn load_remote_track(
+        &self,
+        track_uri: SpotifyUri,
+        track_id: SpotifyId,
+        position_ms: u32,
+    ) -> Option<PlayerLoadedTrackData> {
+        let audio_item = match AudioItem::get_file(&self.session, track_uri).await {
             Ok(audio) => match self.find_available_alternative(audio).await {
                 Some(audio) => audio,
                 None => {
                     warn!(
-                        "<{}> is not available",
-                        spotify_id.to_uri().unwrap_or_default()
+                        "spotify:track:<{}> is not available",
+                        track_id.to_base62().unwrap_or_default()
                     );
                     return None;
                 }
@@ -1033,13 +1068,14 @@ impl PlayerTrackLoader {
             // Not all audio files are encrypted. If we can't get a key, try loading the track
             // without decryption. If the file was encrypted after all, the decoder will fail
             // parsing and bail out, so we should be safe from outputting ear-piercing noise.
-            let key = match self.session.audio_key().request(spotify_id, file_id).await {
+            let key = match self.session.audio_key().request(track_id, file_id).await {
                 Ok(key) => Some(key),
                 Err(e) => {
                     warn!("Unable to load key, continuing without decryption: {e}");
                     None
                 }
             };
+
             let mut decrypted_file = AudioDecrypt::new(key, encrypted_file);
 
             let is_ogg_vorbis = AudioFiles::is_ogg_vorbis(format);
@@ -1195,13 +1231,15 @@ impl Future for PlayerInternal {
             // Handle loading of a new track to play
             if let PlayerState::Loading {
                 ref mut loader,
-                track_id,
+                ref track_id,
                 start_playback,
                 play_request_id,
             } = self.state
             {
                 // The loader may be terminated if we are trying to load the same track
                 // as before, and that track failed to open before.
+                let track_id = track_id.clone();
+
                 if !loader.as_mut().is_terminated() {
                     match loader.as_mut().poll(cx) {
                         Poll::Ready(Ok(loaded_track)) => {
@@ -1233,12 +1271,15 @@ impl Future for PlayerInternal {
             // handle pending preload requests.
             if let PlayerPreload::Loading {
                 ref mut loader,
-                track_id,
+                ref track_id,
             } = self.preload
             {
+                let track_id = track_id.clone();
                 match loader.as_mut().poll(cx) {
                     Poll::Ready(Ok(loaded_track)) => {
-                        self.send_event(PlayerEvent::Preloading { track_id });
+                        self.send_event(PlayerEvent::Preloading {
+                            track_id: track_id.clone(),
+                        });
                         self.preload = PlayerPreload::Ready {
                             track_id,
                             loaded_track: Box::new(loaded_track),
@@ -1269,7 +1310,7 @@ impl Future for PlayerInternal {
                 self.ensure_sink_running();
 
                 if let PlayerState::Playing {
-                    track_id,
+                    ref track_id,
                     play_request_id,
                     ref mut decoder,
                     normalisation_factor,
@@ -1278,6 +1319,7 @@ impl Future for PlayerInternal {
                     ..
                 } = self.state
                 {
+                    let track_id = track_id.clone();
                     match decoder.next_packet() {
                         Ok(result) => {
                             if let Some((ref packet_position, ref packet)) = result {
@@ -1338,7 +1380,7 @@ impl Future for PlayerInternal {
                                                     now.checked_sub(new_stream_position);
                                                 self.send_event(PlayerEvent::PositionCorrection {
                                                     play_request_id,
-                                                    track_id,
+                                                    track_id: track_id.clone(),
                                                     position_ms: new_stream_position_ms,
                                                 });
                                             }
@@ -1391,7 +1433,7 @@ impl Future for PlayerInternal {
             }
 
             if let PlayerState::Playing {
-                track_id,
+                ref track_id,
                 play_request_id,
                 duration_ms,
                 stream_position_ms,
@@ -1400,7 +1442,7 @@ impl Future for PlayerInternal {
                 ..
             }
             | PlayerState::Paused {
-                track_id,
+                ref track_id,
                 play_request_id,
                 duration_ms,
                 stream_position_ms,
@@ -1409,6 +1451,8 @@ impl Future for PlayerInternal {
                 ..
             } = self.state
             {
+                let track_id = track_id.clone();
+
                 if (!*suggested_to_preload_next_track)
                     && ((duration_ms as i64 - stream_position_ms as i64)
                         < PRELOAD_NEXT_TRACK_BEFORE_END_DURATION_MS as i64)
@@ -1482,25 +1526,27 @@ impl PlayerInternal {
     fn handle_player_stop(&mut self) {
         match self.state {
             PlayerState::Playing {
-                track_id,
+                ref track_id,
                 play_request_id,
                 ..
             }
             | PlayerState::Paused {
-                track_id,
+                ref track_id,
                 play_request_id,
                 ..
             }
             | PlayerState::EndOfTrack {
-                track_id,
+                ref track_id,
                 play_request_id,
                 ..
             }
             | PlayerState::Loading {
-                track_id,
+                ref track_id,
                 play_request_id,
                 ..
             } => {
+                let track_id = track_id.clone();
+
                 self.ensure_sink_stopped(false);
                 self.send_event(PlayerEvent::Stopped {
                     track_id,
@@ -1519,11 +1565,13 @@ impl PlayerInternal {
     fn handle_play(&mut self) {
         match self.state {
             PlayerState::Paused {
-                track_id,
+                ref track_id,
                 play_request_id,
                 stream_position_ms,
                 ..
             } => {
+                let track_id = track_id.clone();
+
                 self.state.paused_to_playing();
                 self.send_event(PlayerEvent::Playing {
                     track_id,
@@ -1546,11 +1594,13 @@ impl PlayerInternal {
         match self.state {
             PlayerState::Paused { .. } => self.ensure_sink_stopped(false),
             PlayerState::Playing {
-                track_id,
+                ref track_id,
                 play_request_id,
                 stream_position_ms,
                 ..
             } => {
+                let track_id = track_id.clone();
+
                 self.state.playing_to_paused();
 
                 self.ensure_sink_stopped(false);
@@ -1681,13 +1731,13 @@ impl PlayerInternal {
             None => {
                 self.state.playing_to_end_of_track();
                 if let PlayerState::EndOfTrack {
-                    track_id,
+                    ref track_id,
                     play_request_id,
                     ..
                 } = self.state
                 {
                     self.send_event(PlayerEvent::EndOfTrack {
-                        track_id,
+                        track_id: track_id.clone(),
                         play_request_id,
                     })
                 } else {
@@ -1700,7 +1750,7 @@ impl PlayerInternal {
 
     fn start_playback(
         &mut self,
-        track_id: SpotifyId,
+        track_id: SpotifyUri,
         play_request_id: u64,
         loaded_track: PlayerLoadedTrackData,
         start_playback: bool,
@@ -1725,7 +1775,7 @@ impl PlayerInternal {
         if start_playback {
             self.ensure_sink_running();
             self.send_event(PlayerEvent::Playing {
-                track_id,
+                track_id: track_id.clone(),
                 play_request_id,
                 position_ms,
             });
@@ -1750,7 +1800,7 @@ impl PlayerInternal {
             self.ensure_sink_stopped(false);
 
             self.state = PlayerState::Paused {
-                track_id,
+                track_id: track_id.clone(),
                 play_request_id,
                 decoder: loaded_track.decoder,
                 audio_item: loaded_track.audio_item,
@@ -1774,7 +1824,7 @@ impl PlayerInternal {
 
     fn handle_command_load(
         &mut self,
-        track_id: SpotifyId,
+        track_id: SpotifyUri,
         play_request_id_option: Option<u64>,
         play: bool,
         position_ms: u32,
@@ -1803,9 +1853,9 @@ impl PlayerInternal {
         if let PlayerState::EndOfTrack {
             track_id: previous_track_id,
             ..
-        } = self.state
+        } = &self.state
         {
-            if previous_track_id == track_id {
+            if *previous_track_id == track_id {
                 let mut loaded_track = match mem::replace(&mut self.state, PlayerState::Invalid) {
                     PlayerState::EndOfTrack { loaded_track, .. } => loaded_track,
                     _ => {
@@ -1834,19 +1884,19 @@ impl PlayerInternal {
 
         // Check if we are already playing the track. If so, just do a seek and update our info.
         if let PlayerState::Playing {
-            track_id: current_track_id,
+            track_id: ref current_track_id,
             ref mut stream_position_ms,
             ref mut decoder,
             ..
         }
         | PlayerState::Paused {
-            track_id: current_track_id,
+            track_id: ref current_track_id,
             ref mut stream_position_ms,
             ref mut decoder,
             ..
         } = self.state
         {
-            if current_track_id == track_id {
+            if *current_track_id == track_id {
                 // we can use the current decoder. Ensure it's at the correct position.
                 if position_ms != *stream_position_ms {
                     // This may be blocking.
@@ -1915,9 +1965,9 @@ impl PlayerInternal {
         if let PlayerPreload::Ready {
             track_id: loaded_track_id,
             ..
-        } = self.preload
+        } = &self.preload
         {
-            if track_id == loaded_track_id {
+            if track_id == *loaded_track_id {
                 let preload = std::mem::replace(&mut self.preload, PlayerPreload::None);
                 if let PlayerPreload::Ready {
                     track_id,
@@ -1940,7 +1990,7 @@ impl PlayerInternal {
         }
 
         self.send_event(PlayerEvent::Loading {
-            track_id,
+            track_id: track_id.clone(),
             play_request_id,
             position_ms,
         });
@@ -1949,9 +1999,9 @@ impl PlayerInternal {
         let loader = if let PlayerPreload::Loading {
             track_id: loaded_track_id,
             ..
-        } = self.preload
+        } = &self.preload
         {
-            if (track_id == loaded_track_id) && (position_ms == 0) {
+            if (track_id == *loaded_track_id) && (position_ms == 0) {
                 let mut preload = PlayerPreload::None;
                 std::mem::swap(&mut preload, &mut self.preload);
                 if let PlayerPreload::Loading { loader, .. } = preload {
@@ -1969,7 +2019,8 @@ impl PlayerInternal {
         self.preload = PlayerPreload::None;
 
         // If we don't have a loader yet, create one from scratch.
-        let loader = loader.unwrap_or_else(|| Box::pin(self.load_track(track_id, position_ms)));
+        let loader =
+            loader.unwrap_or_else(|| Box::pin(self.load_track(track_id.clone(), position_ms)));
 
         // Set ourselves to a loading state.
         self.state = PlayerState::Loading {
@@ -1982,7 +2033,7 @@ impl PlayerInternal {
         Ok(())
     }
 
-    fn handle_command_preload(&mut self, track_id: SpotifyId) {
+    fn handle_command_preload(&mut self, track_id: SpotifyUri) {
         debug!("Preloading track");
         let mut preload_track = true;
         // check whether the track is already loaded somewhere or being loaded.
@@ -1993,9 +2044,9 @@ impl PlayerInternal {
         | PlayerPreload::Ready {
             track_id: currently_loading,
             ..
-        } = self.preload
+        } = &self.preload
         {
-            if currently_loading == track_id {
+            if *currently_loading == track_id {
                 // we're already preloading the requested track.
                 preload_track = false;
             } else {
@@ -2015,9 +2066,9 @@ impl PlayerInternal {
         | PlayerState::EndOfTrack {
             track_id: current_track_id,
             ..
-        } = self.state
+        } = &self.state
         {
-            if current_track_id == track_id {
+            if *current_track_id == track_id {
                 // we already have the requested track loaded.
                 preload_track = false;
             }
@@ -2025,7 +2076,7 @@ impl PlayerInternal {
 
         // schedule the preload of the current track if desired.
         if preload_track {
-            let loader = self.load_track(track_id, 0);
+            let loader = self.load_track(track_id.clone(), 0);
             self.preload = PlayerPreload::Loading {
                 track_id,
                 loader: Box::pin(loader),
@@ -2039,14 +2090,14 @@ impl PlayerInternal {
         // that. In this case just restart the loading process but
         // with the requested position.
         if let PlayerState::Loading {
-            track_id,
+            ref track_id,
             play_request_id,
             start_playback,
             ..
         } = self.state
         {
             return self.handle_command_load(
-                track_id,
+                track_id.clone(),
                 Some(play_request_id),
                 start_playback,
                 position_ms,
@@ -2058,13 +2109,13 @@ impl PlayerInternal {
                 Ok(new_position_ms) => {
                     if let PlayerState::Playing {
                         ref mut stream_position_ms,
-                        track_id,
+                        ref track_id,
                         play_request_id,
                         ..
                     }
                     | PlayerState::Paused {
                         ref mut stream_position_ms,
-                        track_id,
+                        ref track_id,
                         play_request_id,
                         ..
                     } = self.state
@@ -2073,7 +2124,7 @@ impl PlayerInternal {
 
                         self.send_event(PlayerEvent::Seeked {
                             play_request_id,
-                            track_id,
+                            track_id: track_id.clone(),
                             position_ms: new_position_ms,
                         });
                     }
@@ -2177,18 +2228,20 @@ impl PlayerInternal {
 
                 if filter {
                     if let PlayerState::Playing {
-                        track_id,
+                        ref track_id,
                         play_request_id,
                         is_explicit,
                         ..
                     }
                     | PlayerState::Paused {
-                        track_id,
+                        ref track_id,
                         play_request_id,
                         is_explicit,
                         ..
                     } = self.state
                     {
+                        let track_id = track_id.clone();
+
                         if is_explicit {
                             warn!(
                                 "Currently loaded track is explicit, which client setting forbids -- skipping to next track."
@@ -2213,7 +2266,7 @@ impl PlayerInternal {
 
     fn load_track(
         &mut self,
-        spotify_id: SpotifyId,
+        spotify_uri: SpotifyUri,
         position_ms: u32,
     ) -> impl FusedFuture<Output = Result<PlayerLoadedTrackData, ()>> + Send + 'static {
         // This method creates a future that returns the loaded stream and associated info.
@@ -2231,8 +2284,9 @@ impl PlayerInternal {
 
         let load_handles_clone = self.load_handles.clone();
         let handle = tokio::runtime::Handle::current();
+
         let load_handle = thread::spawn(move || {
-            let data = handle.block_on(loader.load_track(spotify_id, position_ms));
+            let data = handle.block_on(loader.load_track(spotify_uri, position_ms));
             if let Some(data) = data {
                 let _ = result_tx.send(data);
             }
@@ -2376,7 +2430,7 @@ impl fmt::Debug for PlayerCommand {
 impl fmt::Debug for PlayerState {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use PlayerState::*;
-        match *self {
+        match self {
             Stopped => f.debug_struct("Stopped").finish(),
             Loading {
                 track_id,

--- a/src/player_event_handler.rs
+++ b/src/player_event_handler.rs
@@ -28,7 +28,7 @@ impl EventHandler {
                                 env_vars.insert("PLAY_REQUEST_ID", play_request_id.to_string());
                             }
                             PlayerEvent::TrackChanged { audio_item } => {
-                                match audio_item.track_id.to_base62() {
+                                match audio_item.track_id.to_name() {
                                     Err(e) => {
                                         warn!("PlayerEvent::TrackChanged: Invalid track id: {e}")
                                     }
@@ -104,7 +104,7 @@ impl EventHandler {
                                     }
                                 }
                             }
-                            PlayerEvent::Stopped { track_id, .. } => match track_id.to_base62() {
+                            PlayerEvent::Stopped { track_id, .. } => match track_id.to_name() {
                                 Err(e) => warn!("PlayerEvent::Stopped: Invalid track id: {e}"),
                                 Ok(id) => {
                                     env_vars.insert("PLAYER_EVENT", "stopped".to_string());
@@ -115,7 +115,7 @@ impl EventHandler {
                                 track_id,
                                 position_ms,
                                 ..
-                            } => match track_id.to_base62() {
+                            } => match track_id.to_name() {
                                 Err(e) => warn!("PlayerEvent::Playing: Invalid track id: {e}"),
                                 Ok(id) => {
                                     env_vars.insert("PLAYER_EVENT", "playing".to_string());
@@ -127,7 +127,7 @@ impl EventHandler {
                                 track_id,
                                 position_ms,
                                 ..
-                            } => match track_id.to_base62() {
+                            } => match track_id.to_name() {
                                 Err(e) => warn!("PlayerEvent::Paused: Invalid track id: {e}"),
                                 Ok(id) => {
                                     env_vars.insert("PLAYER_EVENT", "paused".to_string());
@@ -135,26 +135,24 @@ impl EventHandler {
                                     env_vars.insert("POSITION_MS", position_ms.to_string());
                                 }
                             },
-                            PlayerEvent::Loading { track_id, .. } => match track_id.to_base62() {
+                            PlayerEvent::Loading { track_id, .. } => match track_id.to_name() {
                                 Err(e) => warn!("PlayerEvent::Loading: Invalid track id: {e}"),
                                 Ok(id) => {
                                     env_vars.insert("PLAYER_EVENT", "loading".to_string());
                                     env_vars.insert("TRACK_ID", id);
                                 }
                             },
-                            PlayerEvent::Preloading { track_id, .. } => {
-                                match track_id.to_base62() {
-                                    Err(e) => {
-                                        warn!("PlayerEvent::Preloading: Invalid track id: {e}")
-                                    }
-                                    Ok(id) => {
-                                        env_vars.insert("PLAYER_EVENT", "preloading".to_string());
-                                        env_vars.insert("TRACK_ID", id);
-                                    }
+                            PlayerEvent::Preloading { track_id, .. } => match track_id.to_name() {
+                                Err(e) => {
+                                    warn!("PlayerEvent::Preloading: Invalid track id: {e}")
                                 }
-                            }
+                                Ok(id) => {
+                                    env_vars.insert("PLAYER_EVENT", "preloading".to_string());
+                                    env_vars.insert("TRACK_ID", id);
+                                }
+                            },
                             PlayerEvent::TimeToPreloadNextTrack { track_id, .. } => {
-                                match track_id.to_base62() {
+                                match track_id.to_name() {
                                     Err(e) => warn!(
                                         "PlayerEvent::TimeToPreloadNextTrack: Invalid track id: {e}"
                                     ),
@@ -164,19 +162,16 @@ impl EventHandler {
                                     }
                                 }
                             }
-                            PlayerEvent::EndOfTrack { track_id, .. } => {
-                                match track_id.to_base62() {
-                                    Err(e) => {
-                                        warn!("PlayerEvent::EndOfTrack: Invalid track id: {e}")
-                                    }
-                                    Ok(id) => {
-                                        env_vars.insert("PLAYER_EVENT", "end_of_track".to_string());
-                                        env_vars.insert("TRACK_ID", id);
-                                    }
+                            PlayerEvent::EndOfTrack { track_id, .. } => match track_id.to_name() {
+                                Err(e) => {
+                                    warn!("PlayerEvent::EndOfTrack: Invalid track id: {e}")
                                 }
-                            }
-                            PlayerEvent::Unavailable { track_id, .. } => match track_id.to_base62()
-                            {
+                                Ok(id) => {
+                                    env_vars.insert("PLAYER_EVENT", "end_of_track".to_string());
+                                    env_vars.insert("TRACK_ID", id);
+                                }
+                            },
+                            PlayerEvent::Unavailable { track_id, .. } => match track_id.to_name() {
                                 Err(e) => warn!("PlayerEvent::Unavailable: Invalid track id: {e}"),
                                 Ok(id) => {
                                     env_vars.insert("PLAYER_EVENT", "unavailable".to_string());
@@ -191,7 +186,7 @@ impl EventHandler {
                                 track_id,
                                 position_ms,
                                 ..
-                            } => match track_id.to_base62() {
+                            } => match track_id.to_name() {
                                 Err(e) => warn!("PlayerEvent::Seeked: Invalid track id: {e}"),
                                 Ok(id) => {
                                     env_vars.insert("PLAYER_EVENT", "seeked".to_string());
@@ -203,7 +198,7 @@ impl EventHandler {
                                 track_id,
                                 position_ms,
                                 ..
-                            } => match track_id.to_base62() {
+                            } => match track_id.to_name() {
                                 Err(e) => {
                                     warn!("PlayerEvent::PositionCorrection: Invalid track id: {e}")
                                 }


### PR DESCRIPTION
Contributes to #1266

Introduces a new `SpotifyUri` struct which is layered on top of the existing `SpotifyId`, but has the capability to support URIs that do not confirm to the canonical base62 encoded format. This allows it to describe URIs like `spotify:local`, `spotify:genre` and others that `SpotifyId` cannot represent.

Changed the internal player state to use these URIs as much as possible, such that the player could in the future accept a URI of the type `spotify:local`, as a means of laying the groundwork for local file support.